### PR TITLE
Show the applied datetime in verbose showmigrations.

### DIFF
--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -22,7 +22,9 @@ class Command(BaseCommand):
         formats = parser.add_mutually_exclusive_group()
         formats.add_argument(
             '--list', '-l', action='store_const', dest='format', const='list',
-            help='Shows a list of all migrations and which are applied.',
+            help='Shows a list of all migrations and which are applied. '
+                 'With a verbosity level of 2 or above the applied datetimes '
+                 'will be included.',
         )
         formats.add_argument(
             '--plan', '-p', action='store_const', dest='format', const='plan',
@@ -84,9 +86,15 @@ class Command(BaseCommand):
                         title = plan_node[1]
                         if graph.nodes[plan_node].replaces:
                             title += " (%s squashed migrations)" % len(graph.nodes[plan_node].replaces)
+                        # Get the applied migration instance
+                        filtered = filter(lambda m: m == plan_node, loader.applied_migrations)
+                        applied_migration = next(filtered, None)
                         # Mark it as applied/unapplied
-                        if plan_node in loader.applied_migrations:
-                            self.stdout.write(" [X] %s" % title)
+                        if applied_migration:
+                            output = " [X] %s" % title
+                            if self.verbosity >= 2:
+                                output += " %s" % applied_migration.applied
+                            self.stdout.write(output)
                         else:
                             self.stdout.write(" [ ] %s" % title)
                         shown.add(plan_node)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1083,7 +1083,8 @@ Shows all migrations in a project. You can choose from one of two formats:
 
 Lists all of the apps Django knows about, the migrations available for each
 app, and whether or not each migration is applied (marked by an ``[X]`` next to
-the migration name).
+the migration name). For a ``--verbosity`` of 2 and above, the applied datetimes
+will also be shown.
 
 Apps without migrations are also listed, but have ``(no migrations)`` printed
 under them.
@@ -1102,6 +1103,11 @@ apps may also be included.
 .. django-admin-option:: --database DATABASE
 
 Specifies the database to examine. Defaults to ``default``.
+
+.. versionchanged:: 2.2
+
+    Using the ``--list`` option with ``--verbosity`` level of 2 and above, the
+    applied datetimes will also be shown.
 
 ``sqlflush``
 ------------

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -132,6 +132,9 @@ Management Commands
   comments in generated migration file(s). This option is also available for
   :djadmin:`squashmigrations`.
 
+* The :djadmin:`showmigrations --list` option will show the applied
+  datetimes when ``--verbosity`` is set to 2 or higher.
+
 * :djadmin:`runserver` can now use `Watchman
   <https://facebook.github.io/watchman/>`_ to improve the performance of
   watching a large number of files for changes.

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -250,6 +250,20 @@ class MigrateTests(MigrationTestBase):
             ' [ ] 0002_second\n',
             out.getvalue().lower()
         )
+
+        out = io.StringIO()
+        # Verify datetime shows for applied datetime
+        call_command("showmigrations", "migrations", stdout=out, verbosity=2, no_color=True)
+        applied = MigrationRecorder(connection).migration_qs.get(
+            app='migrations',
+            name='0001_initial',
+        ).applied
+        self.assertEqual(
+            'migrations\n'
+            ' [x] 0001_initial %s\n'
+            ' [ ] 0002_second\n' % applied,
+            out.getvalue().lower()
+        )
         # Cleanup by unmigrating everything
         call_command("migrate", "migrations", "zero", verbosity=0)
 


### PR DESCRIPTION
When verbosity is 2 or greater and listing migrations with
showmigrations, include the applied datetime in the output.